### PR TITLE
Fixed a bug that caused an exception when changing clothes in KKS

### DIFF
--- a/Core_SkinEffects/SkinEffectsController.cs
+++ b/Core_SkinEffects/SkinEffectsController.cs
@@ -424,6 +424,9 @@ namespace KK_SkinEffects
             DisableDeflowering = false;
             _talkSceneTouchCount = 0;
 
+            if (_ksox == null)
+                _ksox = GetComponent<KoiSkinOverlayController>();
+
             var data = GetExtendedData();
 
             if (!MakerAPI.InsideAndLoaded || MakerAPI.GetCharacterLoadFlags().Parameters)


### PR DESCRIPTION
Fixed a bug that caused an exception when performing certain operations when changing clothes in the KKS studio. Please merge if it is not a problem.

Reproduction procedure:  
1. launch Sunshine studio
2. Load any character
3. Open the Load Costume menu 
4. Click [Show Selection]
5. Click on Switch Costumes

![スクリーンショット 2023-12-01 221709](https://github.com/ManlyMarco/Illusion_SkinEffects/assets/4230203/46d6294d-0de2-4bd7-8215-79613e34ec65)


Log:
```
[Error  :Modding API] System.NullReferenceException: Object reference not set to an instance of an object
  at KK_SkinEffects.SkinEffectsController.ClearCharaState (System.Boolean refreshTextures, System.Boolean forceClothesStateUpdate) [0x00000] in <40cb824239fc4abd9826a3ab907c951c>:0 
  at KK_SkinEffects.SkinEffectsController.ApplyCharaState (System.Collections.Generic.IDictionary`2[TKey,TValue] dataDict, System.Boolean onlyCustomEffects) [0x00008] in <40cb824239fc4abd9826a3ab907c951c>:0 
  at KK_SkinEffects.SkinEffectsController.OnReload (KKAPI.GameMode currentGameMode, System.Boolean maintainState) [0x001dd] in <40cb824239fc4abd9826a3ab907c951c>:0 
  at KKAPI.Chara.CharaCustomFunctionController.OnReloadInternal (KKAPI.GameMode currentGameMode) [0x00038] in <19e1c278317b4a43a2b69f98f72c73c8>:0 
```
[output_log.txt](https://github.com/ManlyMarco/Illusion_SkinEffects/files/13528381/output_log.txt)

Also, the method of getting _ksox in Awake() worked well. However, I thought it was not a good idea to write code in Awake that depends on the behavior of other components (calls to AddComponent<KoiSkinOverlayController>), so I decided to set it up in Reload in a limited way.
It seems to be due to the [Coordinate Load Option] not being well behaved, but it seems that the source code is not available over there, so please allow me to fix it here.
